### PR TITLE
avoid global namespace pollution

### DIFF
--- a/component/soc/realtek/amebad/fwlib/include/rtl8721dhp_sd.h
+++ b/component/soc/realtek/amebad/fwlib/include/rtl8721dhp_sd.h
@@ -72,9 +72,9 @@
   * @endverbatim
   */
 
-#define  SD      		0
-#define  EMMC   		1
-#define  SDIO 		    SD
+#define  RTL_SD     0
+#define  EMMC       1
+#define  SDIO       (RTL_SD)
 
 /* Exported constants --------------------------------------------------------*/
 


### PR DESCRIPTION
Specifically the symbol `SD` is used in numerous Particle libraries and causes compilation problems. 