### PR TITLE
Revert "update the flash speed to use 57MHz on MX25R32"

### DIFF
--- a/component/soc/realtek/amebad/fwlib/usrcfg/rtl8721dlp_flashcfg.c
+++ b/component/soc/realtek/amebad/fwlib/usrcfg/rtl8721dlp_flashcfg.c
@@ -29,7 +29,7 @@ void flash_init_userdef(void);
 *	0x1FFF: 57MHz
 *	0x0FFF: 50MHz
 */
-const u16 Flash_Speed = 0x1FFF;
+const u16 Flash_Speed = 0xFFFF;
 
 /**
 * @brif Indicate the flash read I/O mode. It can be one of the following value:


### PR DESCRIPTION
This is a mistake I made in [PR2470](https://github.com/particle-iot/device-os/pull/2470)

The older datasheet indicates support for QSPI speeds of up to 60MHz, whereas the newer one indicates support for speeds of up to 80MHz.

![v0 03](https://github.com/particle-iot/realtek_ambd_sdk_public/assets/7424522/34b1dd51-1ddb-4e9b-9d0e-ee3201e7483c)

![v1 6](https://github.com/particle-iot/realtek_ambd_sdk_public/assets/7424522/fc0c2676-a0c3-4305-b5da-8e0ca7223f93)
