### PR TITLE
Fix pin toggling on D4, D5, D6, D7 on boot

### DIFF
--- a/component/soc/realtek/amebad/fwlib/ram_lp/rtl8721dlp_flashclk.c
+++ b/component/soc/realtek/amebad/fwlib/ram_lp/rtl8721dlp_flashclk.c
@@ -407,40 +407,14 @@ static void set_drive_strength(uint32_t rtlPin, uint32_t drvStrength) {
 	PINMUX->PADCTR[rtlPin] = temp;
 }
 
-static BOOL configure_spi_pins_if_needed() {
-	const uint32_t spi_pins[] = {_PB_12, _PB_14, _PB_15, _PB_17};
-	BOOL pin_configured = _FALSE;
-
-	for (unsigned i = 0; i < sizeof(spi_pins) / sizeof(uint32_t); i++) {
-		uint32_t padctr = PINMUX->PADCTR[spi_pins[i]];
-		if ((padctr & PAD_BIT_MASK_FUNCTION_ID) != PINMUX_FUNCTION_SPIF) {
-			// Configuring *any* pin for SPI pin function, configures *all* SPI capable pins for SPI pin function
-			Pinmux_SpicCtrl(spi_pins[i], ON);
-			pin_configured = _TRUE;
-		}
-	}
-
-	return pin_configured;
-}
-
 void flash_operation_config(void)
 {
 	u8 read_mode;
 	u8 flash_speed;
-
-	// Backup PB18-21 pin config
-	uint32_t altSpiPinBackup[4] = {};
-    for (unsigned i = 0; i < 4; i++) {
-        altSpiPinBackup[i] = PINMUX->PADCTR[_PB_18+i];
-    }
 	
-	if (configure_spi_pins_if_needed()) {
-		// Restore alt SPI pins config if needed
-	    for (unsigned i = 0; i < 4; i++) {
-	        PINMUX->PADCTR[_PB_18+i] = altSpiPinBackup[i];
-	    }	
-	}
-	
+    // Pinlocation 1 = configure PB12-17 for SPI
+    // PinLocation 0 = configure PB18-23 for SPI
+	Pinmux_SpicCtrl(1, ON);
 	PAD_CMD(_PB_17, ENABLE);
 	PAD_CMD(_PB_15, ENABLE);
 	PAD_CMD(_PB_14, ENABLE);

--- a/component/soc/realtek/amebad/fwlib/ram_lp/rtl8721dlp_flashclk.c
+++ b/component/soc/realtek/amebad/fwlib/ram_lp/rtl8721dlp_flashclk.c
@@ -407,16 +407,40 @@ static void set_drive_strength(uint32_t rtlPin, uint32_t drvStrength) {
 	PINMUX->PADCTR[rtlPin] = temp;
 }
 
+static BOOL configure_spi_pins_if_needed() {
+	const uint32_t spi_pins[] = {_PB_12, _PB_14, _PB_15, _PB_17};
+	BOOL pin_configured = _FALSE;
+
+	for (unsigned i = 0; i < sizeof(spi_pins) / sizeof(uint32_t); i++) {
+		uint32_t padctr = PINMUX->PADCTR[spi_pins[i]];
+		if ((padctr & PAD_BIT_MASK_FUNCTION_ID) != PINMUX_FUNCTION_SPIF) {
+			// Configuring *any* pin for SPI pin function, configures *all* SPI capable pins for SPI pin function
+			Pinmux_SpicCtrl(spi_pins[i], ON);
+			pin_configured = _TRUE;
+		}
+	}
+
+	return pin_configured;
+}
+
 void flash_operation_config(void)
 {
 	u8 read_mode;
 	u8 flash_speed;
 
-	// Particle: Higher drive strength is required for higher frequencies to work correctly
-	Pinmux_SpicCtrl(_PB_17, ON);
-	Pinmux_SpicCtrl(_PB_15, ON);
-	Pinmux_SpicCtrl(_PB_14, ON);
-	Pinmux_SpicCtrl(_PB_12, ON);
+	// Backup PB18-21 pin config
+	uint32_t altSpiPinBackup[4] = {};
+    for (unsigned i = 0; i < 4; i++) {
+        altSpiPinBackup[i] = PINMUX->PADCTR[_PB_18+i];
+    }
+	
+	if (configure_spi_pins_if_needed()) {
+		// Restore alt SPI pins config if needed
+	    for (unsigned i = 0; i < 4; i++) {
+	        PINMUX->PADCTR[_PB_18+i] = altSpiPinBackup[i];
+	    }	
+	}
+	
 	PAD_CMD(_PB_17, ENABLE);
 	PAD_CMD(_PB_15, ENABLE);
 	PAD_CMD(_PB_14, ENABLE);
@@ -425,6 +449,7 @@ void flash_operation_config(void)
 	PAD_PullCtrl(_PB_15, GPIO_PuPd_NOPULL);
 	PAD_PullCtrl(_PB_14, GPIO_PuPd_NOPULL);
 	PAD_PullCtrl(_PB_12, GPIO_PuPd_NOPULL);
+	// Particle: Higher drive strength is required for higher frequencies to work correctly
 	set_drive_strength(_PB_17, PAD_DRV_STRENGTH_2);
 	set_drive_strength(_PB_15, PAD_DRV_STRENGTH_2);
 	set_drive_strength(_PB_14, PAD_DRV_STRENGTH_2);


### PR DESCRIPTION
### Problem
Customers reported unexpected pin toggling on pins D4-D7 on boot after updating to DVOS 6.3.3. We isolated the breaking change to DVOS 6.2.0 -> 6.2.1
The major change in this release was to the QSPI / Exflash driver to enable 4 pin IO operations. Part of this change was to change the pin function of the QSPI pins PB12-PB17.

~~Unbeknownst to us, configuring the pinmux function for the QSPI pins also enables SPI operation on the alternate SPI port, pins PB18-PB21, which are D4-D7 for us.~~

~~The "noise" on the bus are unexpected SPI commands~~

### Solution

~~1. During low level SDK pin initialization, back up the `PINMUX->PADCTR[]` register values for potentially affected pins.~~
~~2. Check the QSPI pins, and only set the SPI pinfunc if the pin is not already configured for that function~~
~~3. If we configured *any* QSPI pin, then *all* of the secondary SPI pins have been erroneously configured and the PADCTR register for each needs to be restored with its previous values. This can cause a glitch on the pin state, but should only happen on first power on.~~

After inspecting the assembly for Pinmux_SpicCtrl, there is a bug in how the function is called. 

The ROM function has the following signature
```
_LONG_CALL_ void Pinmux_SpicCtrl(u32  PinLocation, BOOL Operation);
```
Our understanding was that the `PinLocation` parameter corresponded to the pin mux defines in the sdk, ie `#define _PB_12		(0x2C)	//0x4B0`. After looking at the assembly, this is not the case. 

`PinLocation` should either be `1` to select the "primary" QSPI pins, ie the ones we want PB12-17. If you want the "secondary" set of pins, PB12-17, it should be `0`. 
This function only needs to be called once to configure the entire set of pins, including pullups and drive strength. 

The bug is from how these assembly lines operate on the PinLocation parameter
```
3754:	2801      	cmp	r0, #1                             // subtract 1 from <PinLocation>, if 0 set zero flag. 
3756:	d127      	bne.n	37a8 <Pinmux_SpicCtrl+0x60>    // Jump to label *if* zero flag set. So values > 1 will configure alternate port
``` 
Passing values >1 like `_PB_12` will result in the alternate SPI port being enabled. 

The solution is to only enable the primary QSPI port with `Pinmux_SpicCtrl(1, ON);`
The secondary QSPI port pin config is unaffected and there is no glitch on the D4-D7 pins on boot. 

### Example App

Any app

### References

[sc ticket](https://app.shortcut.com/particle/story/135048/m-som-m524-pin-toggles-5-9-0-vs-6-3-3)

---

### Completeness

- [x] User is totes amazing for contributing!
- [ ] Contributor has signed CLA ([Info here](https://github.com/spark/firmware/blob/develop/CONTRIBUTING.md))
- [ ] Problem and Solution clearly stated
- [ ] Run unit/integration/application tests on device
- [ ] Added documentation
- [ ] Added to CHANGELOG.md after merging (add links to docs and issues)
